### PR TITLE
adds support for custom element to bind Faltpickr

### DIFF
--- a/spec/fixtures/index-custom.html
+++ b/spec/fixtures/index-custom.html
@@ -1,0 +1,4 @@
+<div data-controller="datepicker">
+  <input type="text" id="datepicker" data-target="datepicker.instance" />
+  <input type="text" id="other-input" />
+</div>

--- a/spec/flatpickr_custom_element_spec.js
+++ b/spec/flatpickr_custom_element_spec.js
@@ -1,0 +1,33 @@
+import { Application } from 'stimulus'
+import chai, { expect } from 'chai'
+import chaiDom from 'chai-dom'
+
+import StimulusFlatpickr from './controllers/flatpickr_controller'
+import { nextFrame, beforeEachSuite } from './helpers'
+
+import 'flatpickr/dist/flatpickr.css'
+
+var controller
+
+const application = Application.start()
+
+chai.use(chaiDom)
+
+describe('Flatpickr Custom element Controller tests', function() {
+  beforeEachSuite('initialize controller', async function() {
+    fixture.load('index-custom.html')
+    application.register('datepicker', StimulusFlatpickr)
+    await nextFrame()
+    controller = application.controllers[0]
+  })
+
+  describe('Initial state', function() {
+    it('Stimulus flatpickr controller is initialized', function() {
+      expect(controller).to.exist
+    })
+
+    it('flatpickr instance exists', function() {
+      expect(controller.fp).to.exist
+    })
+  })
+})

--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,8 @@ import { elements } from './elements'
 import { convertDateFormat } from './strftime_mapping'
 
 class StimulusFlatpickr extends Controller {
+  static targets = ['instance']
+
   initialize() {
     this.config = {}
   }
@@ -16,7 +18,7 @@ class StimulusFlatpickr extends Controller {
     this._initializeOptions()
     this._initializeDateFormats()
 
-    this.fp = flatpickr(this.element, {
+    this.fp = flatpickr(this.flatpickrElement, {
       ...this.config
     })
 
@@ -112,6 +114,10 @@ class StimulusFlatpickr extends Controller {
 
   _number(option) {
     return parseInt(this.data.get(option))
+  }
+
+  get flatpickrElement() {
+    return (this.hasInstanceTarget && this.instanceTarget) || this.element
   }
 }
 


### PR DESCRIPTION
as per #35 

This PR introduces a new way to initialize the datepicker. It is now possible to specify a custom element within the controller scope to attach the datepicker to.

There is a new reserved Stimulus Target `instance` for this.

example

``` html
<div data-controller="flatpickr" >
  <input data-target="flatpickr.instance">
</div>
```
