### PR TITLE
change UMD name to StimulusFlatpickr

### DIFF
--- a/dist/index.umd.js
+++ b/dist/index.umd.js
@@ -1,7 +1,7 @@
 (function (global, factory) {
   typeof exports === 'object' && typeof module !== 'undefined' ? module.exports = factory(require('stimulus'), require('flatpickr')) :
   typeof define === 'function' && define.amd ? define(['stimulus', 'flatpickr'], factory) :
-  (global = global || self, global['stimulus-flatpickr'] = factory(global.Stimulus, global.Flatpickr));
+  (global = global || self, global.StimulusFlatpikcr = factory(global.Stimulus, global.Flatpickr));
 }(this, (function (stimulus, flatpickr) { 'use strict';
 
   flatpickr = flatpickr && Object.prototype.hasOwnProperty.call(flatpickr, 'default') ? flatpickr['default'] : flatpickr;

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "umd:main": "dist/index.umd.js",
   "module": "dist/index.m.js",
   "source": "src/index.js",
-  "amdName": "StimulusFlatpikcr",
+  "amdName": "StimulusFlatpickr",
   "author": "@adrienpoly",
   "license": "MIT",
   "external": "stimulus, flatpickr",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "umd:main": "dist/index.umd.js",
   "module": "dist/index.m.js",
   "source": "src/index.js",
+  "amdName": "StimulusFlatpikcr",
   "author": "@adrienpoly",
   "license": "MIT",
   "external": "stimulus, flatpickr",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -4,8 +4,6 @@ import babel from 'rollup-plugin-babel'
 
 const pkg = require('./package.json')
 
-const name = pkg.name
-
 export default {
   input: 'src/index.js',
   external: ['stimulus', 'flatpickr'],
@@ -23,7 +21,7 @@ export default {
     {
       file: 'dist/index.umd.js',
       format: 'umd',
-      name,
+      name: pkg.amdName,
       sourcemap: true,
       globals: {
         stimulus: 'Stimulus',


### PR DESCRIPTION
UMD name wasn't properly defined. It was `stimulus-flatpickr` not respecting capitalized naming convention
This PR sets the UMD name to `StimulusFlatpickr`

fix #63 