### PR TITLE
Adds importmap installation guide under install section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -83,7 +83,7 @@ Note: Do not use both `yarn` and `npm` to install packages, this might lead to a
 ### Using importmap
 
 ```bash
-./bin/importmap pin flatpickr stimulus-flatpickr
+./bin/importmap pin flatpickr stimulus-flatpickr@beta
 ```
 
 ## Basic usage

--- a/readme.md
+++ b/readme.md
@@ -80,6 +80,12 @@ npm i stimulus-flatpickr
 ```
 Note: Do not use both `yarn` and `npm` to install packages, this might lead to an error: `...It is advised not to mix package managers in order to avoid resolution inconsistencies caused by unsynchronized lock files`
 
+### Using importmap
+
+```bash
+./bin/importmap pin flatpickr stimulus-flatpickr
+```
+
 ## Basic usage
 
 If you only need to convert an input field in a DateTime picker, you just need to register a standard Stimulus controller and add some markup to your input field.


### PR DESCRIPTION
## Changes
This PR adds a guide on installing `stimulus-flatpickr` with [import maps](https://github.com/rails/importmap-rails).

### Example
```
./bin/importmap pin flatpickr stimulus-flatpickr@beta

Pinning "flatpickr" to https://ga.jspm.io/npm:flatpickr@4.6.13/dist/esm/index.js
Pinning "stimulus-flatpickr" to https://ga.jspm.io/npm:stimulus-flatpickr@1.4.0/dist/index.js
Pinning "stimulus" to https://ga.jspm.io/npm:stimulus@3.2.2/dist/stimulus.js
```
You can then use it in your application.js entrypoint like you would any other module.